### PR TITLE
SLING-11149 - Expose information about cleaned up leftover ThreadLocal values

### DIFF
--- a/src/main/java/org/apache/sling/commons/threads/impl/ThreadLocalCleaner.java
+++ b/src/main/java/org/apache/sling/commons/threads/impl/ThreadLocalCleaner.java
@@ -32,8 +32,6 @@ import org.slf4j.LoggerFactory;
 public class ThreadLocalCleaner {
     
     private static final Logger LOG = LoggerFactory.getLogger(ThreadLocalCleaner.class);
-
-    private static final String CLEANUP_COUNTER = "commons.threads.tp.threadLocalCleanup";
     
     /* Reflection fields */
     /** this field is in class {@link ThreadLocal} and is of type {@code ThreadLocal.ThreadLocalMap} */

--- a/src/main/java/org/apache/sling/commons/threads/impl/ThreadLocalCleaner.java
+++ b/src/main/java/org/apache/sling/commons/threads/impl/ThreadLocalCleaner.java
@@ -130,13 +130,13 @@ public class ThreadLocalCleaner {
             Thread thread = Thread.currentThread();
             if (value == null) {
                 field.set(thread, null);
-                LOG.debug("Restored {} to a null value", field.getName());
+                LOG.warn("Restored {} to a null value", field.getName());
             } else {
                 final Object threadLocals = field.get(thread);
                 tableField.set(threadLocals, value);
                 threadLocalMapSizeField.set(threadLocals, size);
                 threadLocalMapThresholdField.set(threadLocals, threshold);
-                LOG.debug("Restored {} with to {} references, size {}, threshold {}" ,field.getName(), value.length, size, threshold);
+                LOG.warn("Restored {} with to {} references, size {}, threshold {}" ,field.getName(), value.length, size, threshold);
             }
         } catch (IllegalAccessException e) {
             throw new IllegalStateException("Access denied", e);

--- a/src/main/java/org/apache/sling/commons/threads/impl/ThreadPoolExecutorCleaningThreadLocals.java
+++ b/src/main/java/org/apache/sling/commons/threads/impl/ThreadPoolExecutorCleaningThreadLocals.java
@@ -24,7 +24,6 @@ import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +33,8 @@ import org.slf4j.LoggerFactory;
  */
 public class ThreadPoolExecutorCleaningThreadLocals extends ThreadPoolExecutor {
     private final ThreadLocalChangeListener listener;
+
+    private long cleanupCounter = 0;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -68,8 +69,14 @@ public class ThreadPoolExecutorCleaningThreadLocals extends ThreadPoolExecutor {
 
         if (cleaner != null) {
             cleaner.cleanup();
+            this.cleanupCounter++;
+            LOGGER.debug("Cleanup of thread locals performed for thread {}", Thread.currentThread());
         } else {
             LOGGER.warn("Could not clean up thread locals in thread {} as the cleaner was not set up correctly", Thread.currentThread());
         }
+    }
+
+    public long getCleanupCounter() {
+        return this.cleanupCounter;
     }
 }

--- a/src/main/java/org/apache/sling/commons/threads/impl/ThreadPoolMBeanImpl.java
+++ b/src/main/java/org/apache/sling/commons/threads/impl/ThreadPoolMBeanImpl.java
@@ -17,10 +17,8 @@
 package org.apache.sling.commons.threads.impl;
 
 import java.util.concurrent.ThreadPoolExecutor;
-
 import javax.management.NotCompliantMBeanException;
 import javax.management.StandardMBean;
-
 import org.apache.sling.commons.threads.impl.DefaultThreadPoolManager.Entry;
 import org.apache.sling.commons.threads.jmx.ThreadPoolMBean;
 
@@ -95,6 +93,15 @@ class ThreadPoolMBeanImpl extends StandardMBean implements ThreadPoolMBean {
         final ThreadPoolExecutor tpe = this.entry.getExecutor();
         if ( tpe != null ) {
             return tpe.getTaskCount();
+        } else {
+            return -1;
+        }
+    }
+
+    public long getThreadLocalCleanupCount() {
+        final ThreadPoolExecutor tpe = this.entry.getExecutor();
+        if(tpe instanceof ThreadPoolExecutorCleaningThreadLocals) {
+            return ((ThreadPoolExecutorCleaningThreadLocals)tpe).getCleanupCounter();
         } else {
             return -1;
         }

--- a/src/main/java/org/apache/sling/commons/threads/jmx/ThreadPoolMBean.java
+++ b/src/main/java/org/apache/sling/commons/threads/jmx/ThreadPoolMBean.java
@@ -149,6 +149,14 @@ public interface ThreadPoolMBean {
     int getShutdownWaitTimeMs();
 
     /**
+     * Return the amount of thread local cleanups performed
+     *
+     * @return the amount of thread local cleanups performed or -1 if the executor is null
+     *              or not of type {@link org.apache.sling.commons.threads.impl.ThreadPoolExecutorCleaningThreadLocals}
+     */
+    long getThreadLocalCleanupCount();
+
+    /**
      * Return whether or not the thread pool creates daemon threads.
      * 
      * @return The daemon configuration.

--- a/src/main/java/org/apache/sling/commons/threads/jmx/package-info.java
+++ b/src/main/java/org/apache/sling/commons/threads/jmx/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("1.1.1")
+@Version("1.2.0")
 package org.apache.sling.commons.threads.jmx;
 
 import org.osgi.annotation.versioning.Version;

--- a/src/test/java/org/apache/sling/commons/threads/impl/ThreadPoolExecutorCleaningThreadLocalsTest.java
+++ b/src/test/java/org/apache/sling/commons/threads/impl/ThreadPoolExecutorCleaningThreadLocalsTest.java
@@ -24,9 +24,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionHandler;
- import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
 import org.apache.sling.commons.threads.impl.ThreadLocalChangeListener.Mode;
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,8 +50,8 @@ public class ThreadPoolExecutorCleaningThreadLocalsTest {
         final BlockingQueue<Runnable> queue = new ArrayBlockingQueue<Runnable>(20);
         final RejectedExecutionHandler rejectionHandler = new ThreadPoolExecutor.AbortPolicy();
         pool = new ThreadPoolExecutorCleaningThreadLocals(
-                    1, 1, 100, TimeUnit.MILLISECONDS,
-                    queue, Executors.defaultThreadFactory(), rejectionHandler, listener);
+                1, 1, 100, TimeUnit.MILLISECONDS,
+                queue, Executors.defaultThreadFactory(), rejectionHandler, listener);
         Mockito.when(listener.isEnabled()).thenReturn(true);
     }
     
@@ -77,6 +76,14 @@ public class ThreadPoolExecutorCleaningThreadLocalsTest {
         Mockito.verify(listener).changed(ArgumentMatchers.eq(Mode.ADDED), ArgumentMatchers.any(Thread.class), ArgumentMatchers.eq(ThreadLocalTask.threadLocalVariable), ArgumentMatchers.eq("test"));
         // no thread locals should have been removed
         Mockito.verify(listener, Mockito.times(0)).changed(ArgumentMatchers.eq(Mode.REMOVED), ArgumentMatchers.any(Thread.class), ArgumentMatchers.eq(ThreadLocalTask.threadLocalVariable), ArgumentMatchers.anyString());
+    }
+
+    @Test(timeout = 10000)
+    public void testThreadLocalCleanupCount() {
+        pool.beforeExecute(Thread.currentThread(), null);
+        pool.afterExecute(Thread.currentThread(), null);
+        Assert.assertEquals(1, pool.getCleanupCounter());
+
     }
 
     private void assertTaskDoesNotSeeOldThreadLocals(String value) throws InterruptedException, ExecutionException {

--- a/src/test/java/org/apache/sling/commons/threads/impl/ThreadPoolMBeanTest.java
+++ b/src/test/java/org/apache/sling/commons/threads/impl/ThreadPoolMBeanTest.java
@@ -1,0 +1,57 @@
+package org.apache.sling.commons.threads.impl;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.apache.sling.commons.threads.jmx.ThreadPoolMBean;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ThreadPoolMBeanTest {
+
+    private ThreadPoolMBean threadPoolMBean;
+
+    @Mock
+    private DefaultThreadPoolManager.Entry entry;
+
+    @Mock
+    private ThreadLocalChangeListener listener;
+
+    final BlockingQueue<Runnable> queue = new ArrayBlockingQueue<Runnable>(20);
+    final RejectedExecutionHandler rejectionHandler = new ThreadPoolExecutor.AbortPolicy();
+
+    @Before
+    public void setUp() throws Exception {
+        threadPoolMBean = new ThreadPoolMBeanImpl(entry);
+    }
+
+    @Test
+    public void testThreadLocalCleanupCount() {
+        ThreadPoolExecutor pool = new ThreadPoolExecutorCleaningThreadLocals(
+                1, 1, 100, TimeUnit.MILLISECONDS,
+                queue, Executors.defaultThreadFactory(), rejectionHandler, listener);
+        doReturn(pool).when(entry).getExecutor();
+        assertTrue(threadPoolMBean.getThreadLocalCleanupCount() > -1);
+    }
+
+    @Test
+    public void testThreadLocalCleanupCountWithNormalExecutor() {
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(
+                1, 1, 100, TimeUnit.MILLISECONDS,
+                queue, Executors.defaultThreadFactory(), rejectionHandler);
+        doReturn(pool).when(entry).getExecutor();
+        assertEquals(-1, threadPoolMBean.getThreadLocalCleanupCount());
+    }
+
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Exposed the info about cleanup operations using gauges so every threadpool has its own gauge.  

Another way to expose this info would be to use a `MetricsService.counter(...)` but I could only make this work by passing the bundleContext through several classes and that is not so elegant.


About the other part of the ticket

> log with a WARN level any cleanup operation. Care must be taken to not overflow the logs, so maybe a way of only reporting a cleanup for a certain key once can be used (memory-bound)

I wasn't sure what "reporting a cleanup for **a certain key** once" meant.  
I added a WARN logging for every thread once, based on `Thread.getId()`, using an in-memory cache (Set) of processed threads, but I'm not sure that's OK.